### PR TITLE
Support noble only

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,0 @@
-gz-common7 (6.999.999-1~jammy) jammy; urgency=medium
-
-  * Stub to be removed after first entry
-
- -- Carlos Aguero <caguero@openrobotics.org>  Tue, 08 Oct 2024 20:50:47 +0200
-

--- a/jammy/debian/compat
+++ b/jammy/debian/compat
@@ -1,1 +1,0 @@
-../../ubuntu/debian/compat

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,0 @@
-../../ubuntu/debian/control

--- a/jammy/debian/copyright
+++ b/jammy/debian/copyright
@@ -1,1 +1,0 @@
-../../ubuntu/debian/debian_copyright_2022

--- a/jammy/debian/docs
+++ b/jammy/debian/docs
@@ -1,1 +1,0 @@
-../../ubuntu/debian/docs

--- a/jammy/debian/libgz-common-dev.examples
+++ b/jammy/debian/libgz-common-dev.examples
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-dev.examples

--- a/jammy/debian/libgz-common7-av-dev.install
+++ b/jammy/debian/libgz-common7-av-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-av-dev.install

--- a/jammy/debian/libgz-common7-av.install
+++ b/jammy/debian/libgz-common7-av.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-av.install

--- a/jammy/debian/libgz-common7-core-dev.install
+++ b/jammy/debian/libgz-common7-core-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-core-dev.install

--- a/jammy/debian/libgz-common7-dev.install
+++ b/jammy/debian/libgz-common7-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-dev.install

--- a/jammy/debian/libgz-common7-events-dev.install
+++ b/jammy/debian/libgz-common7-events-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-events-dev.install

--- a/jammy/debian/libgz-common7-events.install
+++ b/jammy/debian/libgz-common7-events.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-events.install

--- a/jammy/debian/libgz-common7-geospatial-dev.install
+++ b/jammy/debian/libgz-common7-geospatial-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-geospatial-dev.install

--- a/jammy/debian/libgz-common7-geospatial.install
+++ b/jammy/debian/libgz-common7-geospatial.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-geospatial.install

--- a/jammy/debian/libgz-common7-graphics-dev.install
+++ b/jammy/debian/libgz-common7-graphics-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-graphics-dev.install

--- a/jammy/debian/libgz-common7-graphics.install
+++ b/jammy/debian/libgz-common7-graphics.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-graphics.install

--- a/jammy/debian/libgz-common7-io-dev.install
+++ b/jammy/debian/libgz-common7-io-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-io-dev.install

--- a/jammy/debian/libgz-common7-io.install
+++ b/jammy/debian/libgz-common7-io.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-io.install

--- a/jammy/debian/libgz-common7-profiler-dev.install
+++ b/jammy/debian/libgz-common7-profiler-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-profiler-dev.install

--- a/jammy/debian/libgz-common7-profiler.install
+++ b/jammy/debian/libgz-common7-profiler.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-profiler.install

--- a/jammy/debian/libgz-common7-testing-dev.install
+++ b/jammy/debian/libgz-common7-testing-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-testing-dev.install

--- a/jammy/debian/libgz-common7-testing.install
+++ b/jammy/debian/libgz-common7-testing.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common-testing.install

--- a/jammy/debian/libgz-common7.install
+++ b/jammy/debian/libgz-common7.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-common.install

--- a/jammy/debian/rules
+++ b/jammy/debian/rules
@@ -1,1 +1,0 @@
-../../ubuntu/debian/rules

--- a/jammy/debian/source
+++ b/jammy/debian/source
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source

--- a/jammy/debian/tests
+++ b/jammy/debian/tests
@@ -1,1 +1,0 @@
-../../ubuntu/debian/tests

--- a/jammy/debian/watch
+++ b/jammy/debian/watch
@@ -1,1 +1,0 @@
-../../ubuntu/debian/watch


### PR DESCRIPTION
The next Gazebo distribution will support only noble and newer versions of Ubuntu. This PR adds noble and removes older distributions.