### PR TITLE
Fix doxygen tag.xml install path

### DIFF
--- a/ubuntu/debian/libgz-common-core-dev.install
+++ b/ubuntu/debian/libgz-common-core-dev.install
@@ -4,4 +4,4 @@ usr/include/*/common[0-99]/*/common/detail/*.hh
 usr/lib/*/lib*-common.so
 usr/lib/*/pkgconfig/*-common.pc
 usr/lib/*/cmake/*-common/*-common*
-usr/share/gz/*-common[0-99]/*-common*.tag.xml
+usr/share/gz/*-common/*-common*.tag.xml

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -8,8 +8,8 @@ override_dh_auto_configure:
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 override_dh_install:
-	install -d debian/tmp/usr/share/gz/gz-common7/
-	install ./obj-*/*.tag.xml debian/tmp/usr/share/gz/gz-common7/
+	install -d debian/tmp/usr/share/gz/gz-common/
+	install ./obj-*/*.tag.xml debian/tmp/usr/share/gz/gz-common/
 	dh_install --
 	# need to remove files present in components
 	$(RM) debian/libgz-common7-core-dev/usr/include/gz/common*/ignition/common/av.hh


### PR DESCRIPTION
Needed by https://github.com/gazebosim/gz-fuel-tools/pull/464

From [github workflow](https://github.com/gazebosim/gz-fuel-tools/actions/runs/14787794876/job/41519240132?pr=464):

~~~
 error: Tag file '/usr/share/gz/gz-common/gz-common.tag.xml' does not exist or is not a file. Skipping it...
~~~

The fix is to remove the version number from the install path.